### PR TITLE
feat: implementar gestión de goles de jugadores en enfrentamientos

### DIFF
--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/application/services/JugadorService.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/application/services/JugadorService.java
@@ -117,4 +117,9 @@ public class JugadorService implements JugadorUseCase {
         
         return jugadorRepositoryPort.guardar(jugador);
     }
+    
+    @Override
+    public List<Jugador> obtenerGoleadoresPorTorneo(Long torneoId) {
+        return jugadorRepositoryPort.buscarGoleadoresPorTorneo(torneoId);
+    }
 }

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/in/EnfrentamientoUseCase.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/in/EnfrentamientoUseCase.java
@@ -15,6 +15,8 @@ public interface EnfrentamientoUseCase {
     
     Enfrentamiento registrarResultado(Long enfrentamientoId, int golesLocal, int golesVisitante);
     
+    void registrarGolesJugador(Long enfrentamientoId, Long jugadorId, int cantidadGoles);
+    
     Enfrentamiento cancelarEnfrentamiento(Long enfrentamientoId);
     
     Optional<Enfrentamiento> obtenerEnfrentamientoPorId(Long enfrentamientoId);

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/in/JugadorUseCase.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/in/JugadorUseCase.java
@@ -23,4 +23,6 @@ public interface JugadorUseCase {
     void eliminarJugadoresPorEquipo(Long equipoId);
     
     Jugador cambiarEquipo(Long jugadorId, Long nuevoEquipoId);
+    
+    List<Jugador> obtenerGoleadoresPorTorneo(Long torneoId);
 }

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/out/JugadorRepositoryPort.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/domain/ports/out/JugadorRepositoryPort.java
@@ -24,4 +24,6 @@ public interface JugadorRepositoryPort {
     void eliminarPorId(Long id);
     
     void eliminarPorEquipoId(Long equipoId);
+    
+    List<Jugador> buscarGoleadoresPorTorneo(Long torneoId);
 }

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/EnfrentamientoController.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/EnfrentamientoController.java
@@ -1,12 +1,12 @@
 package com.futnorte.torneo.infrastructure.adapters.in.web;
 
 import com.futnorte.torneo.domain.entities.Enfrentamiento;
-import com.futnorte.torneo.domain.entities.Equipo;
 import com.futnorte.torneo.domain.ports.in.EnfrentamientoUseCase;
 import com.futnorte.torneo.domain.ports.in.EquipoUseCase;
 import com.futnorte.torneo.infrastructure.adapters.in.web.dto.ActualizarEnfrentamientoRequest;
 import com.futnorte.torneo.infrastructure.adapters.in.web.dto.CrearEnfrentamientoRequest;
 import com.futnorte.torneo.infrastructure.adapters.in.web.dto.EnfrentamientoResponse;
+import com.futnorte.torneo.infrastructure.adapters.in.web.dto.RegistrarGolesJugadorRequest;
 import com.futnorte.torneo.infrastructure.adapters.in.web.dto.RegistrarResultadoRequest;
 import jakarta.validation.Valid;
 import org.springframework.format.annotation.DateTimeFormat;
@@ -115,6 +115,24 @@ public class EnfrentamientoController {
             );
             EnfrentamientoResponse response = toResponse(enfrentamiento);
             return new ResponseEntity<>(response, HttpStatus.OK);
+        } catch (IllegalArgumentException e) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        } catch (IllegalStateException e) {
+            return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
+        }
+    }
+    
+    @PostMapping("/{id}/goles-jugador")
+    public ResponseEntity<Void> registrarGolesJugador(
+            @PathVariable Long id, 
+            @Valid @RequestBody RegistrarGolesJugadorRequest request) {
+        try {
+            enfrentamientoUseCase.registrarGolesJugador(
+                    id, 
+                    request.getJugadorId(), 
+                    request.getCantidadGoles()
+            );
+            return new ResponseEntity<>(HttpStatus.OK);
         } catch (IllegalArgumentException e) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } catch (IllegalStateException e) {

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/dto/GoleadorResponse.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/dto/GoleadorResponse.java
@@ -1,0 +1,19 @@
+package com.futnorte.torneo.infrastructure.adapters.in.web.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class GoleadorResponse {
+    
+    private Long id;
+    private String nombre;
+    private String apellido;
+    private String identificacion;
+    private String nacionalidad;
+    private int numeroGoles;
+    private String nombreEquipo;
+}

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/dto/RegistrarGolesJugadorRequest.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/in/web/dto/RegistrarGolesJugadorRequest.java
@@ -1,0 +1,20 @@
+package com.futnorte.torneo.infrastructure.adapters.in.web.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class RegistrarGolesJugadorRequest {
+    
+    @NotNull(message = "El ID del jugador es obligatorio")
+    private Long jugadorId;
+    
+    @NotNull(message = "La cantidad de goles es obligatoria")
+    @Min(value = 1, message = "La cantidad de goles debe ser al menos 1")
+    private Integer cantidadGoles;
+}

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/out/persistence/JugadorJpaRepository.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/out/persistence/JugadorJpaRepository.java
@@ -1,6 +1,8 @@
 package com.futnorte.torneo.infrastructure.adapters.out.persistence;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 import java.util.List;
@@ -16,4 +18,9 @@ public interface JugadorJpaRepository extends JpaRepository<JugadorEntity, Long>
     boolean existsByIdentificacion(String identificacion);
     
     void deleteByEquipoId(Long equipoId);
+    
+    @Query("SELECT j FROM JugadorEntity j WHERE j.equipoId IN " +
+           "(SELECT e.id FROM EquipoEntity e WHERE e.torneoId = :torneoId) " +
+           "AND j.numeroGoles > 0 ORDER BY j.numeroGoles DESC")
+    List<JugadorEntity> findGoleadoresByTorneoId(@Param("torneoId") Long torneoId);
 }

--- a/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/out/persistence/JugadorRepositoryAdapter.java
+++ b/torneo-futnorte-api/src/main/java/com/futnorte/torneo/infrastructure/adapters/out/persistence/JugadorRepositoryAdapter.java
@@ -75,4 +75,12 @@ public class JugadorRepositoryAdapter implements JugadorRepositoryPort {
     public void eliminarPorEquipoId(Long equipoId) {
         jugadorJpaRepository.deleteByEquipoId(equipoId);
     }
+    
+    @Override
+    public List<Jugador> buscarGoleadoresPorTorneo(Long torneoId) {
+        return jugadorJpaRepository.findGoleadoresByTorneoId(torneoId)
+                .stream()
+                .map(jugadorMapper::toDomain)
+                .collect(Collectors.toList());
+    }
 }

--- a/torneo-futnorte-api/src/main/resources/data.sql
+++ b/torneo-futnorte-api/src/main/resources/data.sql
@@ -208,7 +208,7 @@ INSERT INTO jugadores (nombre, apellido, identificacion, nacionalidad, equipo_id
 
 -- Enfrentamientos del torneo Liga Premier 2024 (torneo_id = 1)
 INSERT INTO enfrentamientos (torneo_id, equipo_local_id, equipo_visitante_id, fecha_hora, cancha, estado, goles_local, goles_visitante) VALUES
-(1, 1, 2, '2024-03-15T20:00:00', 'Estadio Santiago Bernabéu', 'FINALIZADO', 2, 1),
+(1, 1, 2, '2024-03-15T20:00:00', 'Estadio Santiago Bernabéu', 'PROGRAMADO', null, null),
 (1, 3, 4, '2024-03-15T18:00:00', 'Metropolitano', 'FINALIZADO', 1, 1),
 (1, 5, 1, '2024-03-22T21:00:00', 'Ramón Sánchez-Pizjuán', 'FINALIZADO', 0, 3),
 (1, 2, 3, '2024-03-22T19:00:00', 'Camp Nou', 'FINALIZADO', 2, 0),


### PR DESCRIPTION
Agrega funcionalidad completa para registrar y consultar goles de jugadores:
- Registro de goles por jugador en enfrentamientos finalizados
- Endpoint para obtener goleadores por torneo ordenados por cantidad de goles
- Validaciones de negocio para asegurar integridad de datos
- DTOs para requests y responses específicos